### PR TITLE
feat: handle_abandoned hook for client-cancelled requests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,6 +272,58 @@ impl PathFilter {
 ///     }
 /// }
 /// ```
+/// Drop-fired sentinel that `try_send`s a [`BackgroundTask::Abandoned`] if
+/// not [`disarm`](Self::disarm)ed first.
+///
+/// Used by [`RequestLoggerService::call`] to detect the "client cancelled
+/// before any response was produced" path: the outer future is dropped
+/// before reaching the `Ok(response)` arm, so the detached response task
+/// is never spawned and `BackgroundTask::Response` never fires. The guard
+/// catches that drop and feeds an `Abandoned` event into the same
+/// background channel.
+///
+/// The send is best-effort (`try_send`) because Drop runs synchronously
+/// and can't await; if the channel is full or closed, the abandon event is
+/// dropped along with the `outlet_queue_dropped_total` counter, same as
+/// other tasks under back-pressure.
+struct AbandonGuard {
+    tx: mpsc::Sender<BackgroundTask>,
+    data: Option<RequestData>,
+}
+
+impl AbandonGuard {
+    fn new(tx: mpsc::Sender<BackgroundTask>, data: RequestData) -> Self {
+        Self {
+            tx,
+            data: Some(data),
+        }
+    }
+
+    /// Consume the held request data so the guard's Drop becomes a no-op.
+    /// Called once the inner future yields a value — at that point the
+    /// outer flow has either spawned the response task (Ok) or returned
+    /// an error (Err), and neither case is abandonment.
+    fn disarm(&mut self) {
+        self.data.take();
+    }
+}
+
+impl Drop for AbandonGuard {
+    fn drop(&mut self) {
+        if let Some(data) = self.data.take() {
+            if self
+                .tx
+                .try_send(BackgroundTask::Abandoned { data })
+                .is_err()
+            {
+                counter!("outlet_queue_dropped_total").increment(1);
+            } else {
+                counter!("outlet_queue_enqueued_total").increment(1);
+            }
+        }
+    }
+}
+
 pub trait RequestHandler: Send + Sync + 'static {
     /// Handle a captured HTTP request.
     ///
@@ -296,6 +348,30 @@ pub trait RequestHandler: Send + Sync + 'static {
         request_data: RequestData,
         response_data: ResponseData,
     ) -> impl std::future::Future<Output = ()> + Send;
+
+    /// Handle a request whose handler future was dropped before a response
+    /// was produced.
+    ///
+    /// This fires when the inner service future is dropped before completing
+    /// — typically because the client cancelled the connection while an
+    /// upstream call was still in flight. The `request_data` carries
+    /// whatever was captured at request time; the request body may be
+    /// `None` even if capture was enabled, because body capture races the
+    /// inner-future drop.
+    ///
+    /// Default implementation is a no-op so adding this trait method is not
+    /// a breaking change. Override it if you maintain per-request state
+    /// that needs cleanup on abandonment (e.g. terminating a row that
+    /// `handle_response` would otherwise have finalized).
+    ///
+    /// Note that this hook only fires for the "client cancelled before
+    /// response started" path. If the response began streaming and the
+    /// client then dropped, `handle_response` fires with whatever body was
+    /// captured before the stream broke — outlet's response-task spawn
+    /// outlives the outer future once the inner service yields headers.
+    fn handle_abandoned(&self, _data: RequestData) -> impl std::future::Future<Output = ()> + Send {
+        async {}
+    }
 
     /// Handle a batch of captured HTTP requests.
     ///
@@ -334,6 +410,23 @@ pub trait RequestHandler: Send + Sync + 'static {
             let futures: Vec<_> = batch
                 .iter()
                 .map(|(req, res)| self.handle_response(req.clone(), res.clone()))
+                .collect();
+            futures::future::join_all(futures).await;
+        }
+    }
+
+    /// Handle a batch of abandoned requests.
+    ///
+    /// Default implementation calls [`handle_abandoned`] for each item
+    /// concurrently. Override for bulk operations.
+    fn handle_abandoned_batch(
+        &self,
+        batch: &[RequestData],
+    ) -> impl std::future::Future<Output = ()> + Send {
+        async move {
+            let futures: Vec<_> = batch
+                .iter()
+                .map(|data| self.handle_abandoned(data.clone()))
                 .collect();
             futures::future::join_all(futures).await;
         }
@@ -434,9 +527,10 @@ impl RequestLoggerLayer {
 
                 counter!("outlet_queue_dequeued_total").increment(tasks.len() as u64);
 
-                // Separate into request and response batches
+                // Separate into request, response, and abandoned batches
                 let mut request_batch = Vec::new();
                 let mut response_batch = Vec::new();
+                let mut abandoned_batch = Vec::new();
 
                 for task in tasks {
                     match task {
@@ -450,12 +544,14 @@ impl RequestLoggerLayer {
                         } => {
                             response_batch.push((request_data, response_data));
                         }
+                        BackgroundTask::Abandoned { data } => {
+                            abandoned_batch.push(data);
+                        }
                     }
                 }
 
-                // Dispatch request and response batches concurrently.
-                // Each batch is spawned as a task so a panic in one handler
-                // doesn't kill the background loop.
+                // Dispatch batches concurrently. Each batch is spawned as a
+                // task so a panic in one handler doesn't kill the loop.
                 let handler = handler_clone.clone();
                 let req_handle = if !request_batch.is_empty() {
                     let h = handler.clone();
@@ -479,6 +575,20 @@ impl RequestLoggerLayer {
                 } else {
                     None
                 };
+                let abandoned_handle = if !abandoned_batch.is_empty() {
+                    let h = handler.clone();
+                    Some(tokio::spawn(async move {
+                        let span = tracing::info_span!(
+                            "outlet.handle_abandoned_batch",
+                            batch_size = abandoned_batch.len(),
+                        );
+                        h.handle_abandoned_batch(&abandoned_batch)
+                            .instrument(span)
+                            .await;
+                    }))
+                } else {
+                    None
+                };
                 if let Some(handle) = req_handle {
                     if let Err(e) = handle.await {
                         error!("Request batch handler panicked: {}", e);
@@ -487,6 +597,11 @@ impl RequestLoggerLayer {
                 if let Some(handle) = res_handle {
                     if let Err(e) = handle.await {
                         error!("Response batch handler panicked: {}", e);
+                    }
+                }
+                if let Some(handle) = abandoned_handle {
+                    if let Err(e) = handle.await {
+                        error!("Abandoned batch handler panicked: {}", e);
                     }
                 }
             }
@@ -587,6 +702,10 @@ where
                 (None, None)
             }
         };
+        // Cloned copies for the abandon guard built below — the originals are
+        // moved into the request_data_future spawn.
+        let trace_id_for_abandon = trace_id.clone();
+        let span_id_for_abandon = span_id.clone();
 
         trace!(method = %method, uri = %uri, correlation_id = %correlation_id, "Starting request processing");
 
@@ -640,10 +759,36 @@ where
 
         let future = self.inner.call(request);
 
+        // Drop guard for the "client cancelled before any response" path.
+        // If the outer future is dropped between here and the `Ok(response)`
+        // arm (which spawns a detached task that owns continuation), the
+        // guard's Drop synchronously try_sends a `BackgroundTask::Abandoned`
+        // so handlers can clean up per-request state. We build a minimal
+        // RequestData with no body — the real body capture races the inner
+        // drop and isn't guaranteed to land — and feed it to the guard.
+        // After we reach `Ok(response)`, the guard is disarmed so normal
+        // completion doesn't double-fire alongside `BackgroundTask::Response`.
+        let abandon_data = RequestData {
+            correlation_id,
+            timestamp: start_time,
+            method,
+            uri,
+            headers: convert_headers(&headers),
+            body: None,
+            trace_id: trace_id_for_abandon,
+            span_id: span_id_for_abandon,
+        };
+        let mut abandon_guard = AbandonGuard::new(self.tx.clone(), abandon_data);
+
         Box::pin(async move {
             trace!("Awaiting inner service response");
             let result = future.await;
             trace!("Inner service response received");
+
+            // Inner future resolved (Ok or Err) — not an abandonment. Disarm
+            // before the match so neither arm double-fires alongside the
+            // detached response task or with an Err return.
+            abandon_guard.disarm();
 
             match result {
                 Ok(mut response) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -355,20 +355,36 @@ pub trait RequestHandler: Send + Sync + 'static {
     /// This fires when the inner service future is dropped before completing
     /// — typically because the client cancelled the connection while an
     /// upstream call was still in flight. The `request_data` carries
-    /// whatever was captured at request time; the request body may be
-    /// `None` even if capture was enabled, because body capture races the
-    /// inner-future drop.
+    /// whatever was captured synchronously at request time; the request
+    /// body is always `None` because body capture is decoupled (it lives
+    /// on a separate spawned task) and racing it would slow down the
+    /// abandon path's `try_send`.
     ///
     /// Default implementation is a no-op so adding this trait method is not
     /// a breaking change. Override it if you maintain per-request state
     /// that needs cleanup on abandonment (e.g. terminating a row that
     /// `handle_response` would otherwise have finalized).
     ///
-    /// Note that this hook only fires for the "client cancelled before
-    /// response started" path. If the response began streaming and the
-    /// client then dropped, `handle_response` fires with whatever body was
-    /// captured before the stream broke — outlet's response-task spawn
-    /// outlives the outer future once the inner service yields headers.
+    /// # Relationship to `handle_request` and `handle_response`
+    ///
+    /// `handle_request` runs from a task spawned independently of the
+    /// inner service future; it may fire *before* `handle_abandoned`,
+    /// *after*, or not at all, depending on whether request body capture
+    /// completes before the drop. Handlers must NOT assume `handle_request`
+    /// has already been processed when `handle_abandoned` fires, and any
+    /// state created in `handle_request` should be cleaned up
+    /// idempotently here.
+    ///
+    /// `handle_response` and `handle_abandoned` are mutually exclusive for
+    /// a given request: the same drop guard that fires `Abandoned` is
+    /// disarmed the moment the inner future resolves to `Ok(response)` (at
+    /// which point a detached task takes over and fires `Response`).
+    ///
+    /// This hook only fires for the "client cancelled before response
+    /// started" path. If the response began streaming and the client then
+    /// dropped, `handle_response` fires with whatever body was captured
+    /// before the stream broke — outlet's response-task spawn outlives the
+    /// outer future once the inner service yields headers.
     fn handle_abandoned(&self, _data: RequestData) -> impl std::future::Future<Output = ()> + Send {
         async {}
     }

--- a/src/logging_handler.rs
+++ b/src/logging_handler.rs
@@ -60,4 +60,13 @@ impl RequestHandler for LoggingHandler {
             "Response captured"
         );
     }
+
+    async fn handle_abandoned(&self, data: RequestData) {
+        info!(
+            correlation_id = %data.correlation_id,
+            method = %data.method,
+            uri = %data.uri,
+            "Request abandoned (client cancelled before response)"
+        );
+    }
 }

--- a/src/multi_handler.rs
+++ b/src/multi_handler.rs
@@ -34,11 +34,13 @@ trait DynHandler: Send + Sync + 'static {
         request_data: RequestData,
         response_data: ResponseData,
     ) -> BoxFuture<'_>;
+    fn handle_abandoned_boxed(&self, data: RequestData) -> BoxFuture<'_>;
     fn handle_request_batch_boxed<'a>(&'a self, batch: &'a [RequestData]) -> BoxFuture<'a>;
     fn handle_response_batch_boxed<'a>(
         &'a self,
         batch: &'a [(RequestData, ResponseData)],
     ) -> BoxFuture<'a>;
+    fn handle_abandoned_batch_boxed<'a>(&'a self, batch: &'a [RequestData]) -> BoxFuture<'a>;
 }
 
 /// Wrapper that implements DynHandler for any RequestHandler.
@@ -59,6 +61,10 @@ impl<H: RequestHandler> DynHandler for HandlerWrapper<H> {
         Box::pin(self.inner.handle_response(request_data, response_data))
     }
 
+    fn handle_abandoned_boxed(&self, data: RequestData) -> BoxFuture<'_> {
+        Box::pin(self.inner.handle_abandoned(data))
+    }
+
     fn handle_request_batch_boxed<'a>(&'a self, batch: &'a [RequestData]) -> BoxFuture<'a> {
         Box::pin(self.inner.handle_request_batch(batch))
     }
@@ -68,6 +74,10 @@ impl<H: RequestHandler> DynHandler for HandlerWrapper<H> {
         batch: &'a [(RequestData, ResponseData)],
     ) -> BoxFuture<'a> {
         Box::pin(self.inner.handle_response_batch(batch))
+    }
+
+    fn handle_abandoned_batch_boxed<'a>(&'a self, batch: &'a [RequestData]) -> BoxFuture<'a> {
+        Box::pin(self.inner.handle_abandoned_batch(batch))
     }
 }
 
@@ -167,6 +177,28 @@ impl RequestHandler for MultiHandler {
             .handlers
             .iter()
             .map(|h| h.handle_response_batch_boxed(batch))
+            .collect();
+        futures::future::join_all(futures).await;
+    }
+
+    async fn handle_abandoned(&self, data: RequestData) {
+        let futures: Vec<_> = self
+            .handlers
+            .iter()
+            .map(|h| {
+                let data = data.clone();
+                let handler = h.clone();
+                async move { handler.handle_abandoned_boxed(data).await }
+            })
+            .collect();
+        futures::future::join_all(futures).await;
+    }
+
+    async fn handle_abandoned_batch(&self, batch: &[RequestData]) {
+        let futures: Vec<_> = self
+            .handlers
+            .iter()
+            .map(|h| h.handle_abandoned_batch_boxed(batch))
             .collect();
         futures::future::join_all(futures).await;
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -97,4 +97,9 @@ pub(crate) enum BackgroundTask {
         request_data: RequestData,
         response_data: ResponseData,
     },
+    /// The request's handler future was dropped before any response was
+    /// produced — typically because the client cancelled the connection
+    /// while the upstream call was still in flight. Carries the request
+    /// data captured so far so handlers can correlate and clean up.
+    Abandoned { data: RequestData },
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -25,6 +25,7 @@ use std::collections::HashMap;
 struct TestHandler {
     requests: Arc<Mutex<Vec<(RequestData, u64)>>>,
     responses: Arc<Mutex<Vec<(ResponseData, u64)>>>,
+    abandoned: Arc<Mutex<Vec<(RequestData, u64)>>>,
     completed_pairs: Arc<Mutex<HashMap<u64, (RequestData, ResponseData)>>>,
 }
 
@@ -33,6 +34,7 @@ impl TestHandler {
         Self {
             requests: Arc::new(Mutex::new(Vec::new())),
             responses: Arc::new(Mutex::new(Vec::new())),
+            abandoned: Arc::new(Mutex::new(Vec::new())),
             completed_pairs: Arc::new(Mutex::new(HashMap::new())),
         }
     }
@@ -43,6 +45,10 @@ impl TestHandler {
 
     fn get_responses(&self) -> Vec<(ResponseData, u64)> {
         self.responses.lock().unwrap().clone()
+    }
+
+    fn get_abandoned(&self) -> Vec<(RequestData, u64)> {
+        self.abandoned.lock().unwrap().clone()
     }
 
     fn get_completed_pairs(&self) -> Vec<(u64, RequestData, ResponseData)> {
@@ -57,6 +63,17 @@ impl TestHandler {
         let start = SystemTime::now();
         while start.elapsed().unwrap() < timeout {
             if self.completed_pairs.lock().unwrap().len() >= expected_count {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        false
+    }
+
+    fn wait_for_abandoned(&self, expected_count: usize, timeout: Duration) -> bool {
+        let start = SystemTime::now();
+        while start.elapsed().unwrap() < timeout {
+            if self.abandoned.lock().unwrap().len() >= expected_count {
                 return true;
             }
             std::thread::sleep(Duration::from_millis(10));
@@ -84,6 +101,13 @@ impl RequestHandler for TestHandler {
             .lock()
             .unwrap()
             .insert(request_data.correlation_id, (request_data, response_data));
+    }
+
+    async fn handle_abandoned(&self, data: RequestData) {
+        self.abandoned
+            .lock()
+            .unwrap()
+            .push((data.clone(), data.correlation_id));
     }
 }
 
@@ -594,6 +618,93 @@ async fn test_default_batch_impl_calls_individual_methods() {
     ];
     handler.handle_response_batch(&batch).await;
     assert_eq!(response_count.load(Ordering::SeqCst), 2);
+}
+
+// ---------------------------------------------------------------------------
+// Abandoned-request tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_abandoned_fires_when_outer_future_dropped_mid_request() {
+    use tower::ServiceExt;
+
+    // Inner handler that never resolves — simulates an upstream that's
+    // still working when the client drops.
+    async fn pending_handler() -> impl IntoResponse {
+        std::future::pending::<()>().await;
+        "unreachable"
+    }
+
+    let handler = TestHandler::new();
+    let app: Router = Router::new().route("/pending", get(pending_handler)).layer(
+        ServiceBuilder::new()
+            .layer(RequestLoggerLayer::new(
+                RequestLoggerConfig::default(),
+                handler.clone(),
+            ))
+            .into_inner(),
+    );
+
+    let request = axum::http::Request::builder()
+        .method(Method::GET)
+        .uri("/pending")
+        .body(Body::empty())
+        .unwrap();
+
+    // Drive the service and drop the future via timeout. The drop is what
+    // triggers the AbandonGuard's Drop impl in RequestLoggerService::call.
+    let response_future = app.oneshot(request);
+    let result = tokio::time::timeout(Duration::from_millis(100), response_future).await;
+    assert!(
+        result.is_err(),
+        "pending_handler should never resolve — timeout (and drop) is the test path"
+    );
+
+    // Give the background task a moment to dispatch the Abandoned event.
+    assert!(
+        handler.wait_for_abandoned(1, Duration::from_secs(2)),
+        "expected one abandoned event after dropping the request future"
+    );
+    let abandoned = handler.get_abandoned();
+    assert_eq!(abandoned.len(), 1);
+    assert_eq!(abandoned[0].0.method, Method::GET);
+    assert_eq!(abandoned[0].0.uri.path(), "/pending");
+    // No response should have been captured for the abandoned request.
+    assert!(handler.get_responses().is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_abandoned_does_not_fire_on_normal_completion() {
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    let handler = TestHandler::new();
+    let app: Router = Router::new().route("/hello", get(hello_handler)).layer(
+        ServiceBuilder::new()
+            .layer(RequestLoggerLayer::new(
+                RequestLoggerConfig::default(),
+                handler.clone(),
+            ))
+            .into_inner(),
+    );
+
+    let request = axum::http::Request::builder()
+        .method(Method::GET)
+        .uri("/hello")
+        .body(Body::empty())
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    // Drain the body so the outlet capture stream completes — without this,
+    // the response-task spawn is still awaiting body chunks that never flow
+    // (tower::ServiceExt::oneshot returns the response without consuming
+    // the body), and handle_response never fires.
+    let _ = response.into_body().collect().await.unwrap();
+
+    // Wait for the normal response to be captured.
+    assert!(handler.wait_for_pairs(1, Duration::from_secs(2)));
+    // Critically: no abandoned event — the guard was disarmed.
+    assert!(handler.get_abandoned().is_empty());
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -674,6 +674,54 @@ async fn test_abandoned_fires_when_outer_future_dropped_mid_request() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_abandoned_does_not_fire_when_inner_service_returns_err() {
+    use tower::{Layer, Service, ServiceExt};
+
+    // Manual Error impl rather than pulling in thiserror as a dev-dep.
+    #[derive(Debug)]
+    struct SimulatedError;
+    impl std::fmt::Display for SimulatedError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "simulated inner-service error")
+        }
+    }
+    impl std::error::Error for SimulatedError {}
+
+    let handler = TestHandler::new();
+
+    // tower::service_fn with a non-Infallible Error type so the inner
+    // future actually has an Err arm to exercise. axum::Router can't be
+    // used here because its Error is Infallible — 5xx HTTP responses come
+    // back through the Ok(response) arm, not as Err.
+    let inner = tower::service_fn(|_req: axum::http::Request<axum::body::Body>| async move {
+        Err::<axum::response::Response, SimulatedError>(SimulatedError)
+    });
+    let layer = RequestLoggerLayer::new(RequestLoggerConfig::default(), handler.clone());
+    let mut service = layer.layer(inner);
+
+    let request = axum::http::Request::builder()
+        .method(Method::GET)
+        .uri("/err")
+        .body(Body::empty())
+        .unwrap();
+    let result: Result<axum::response::Response, SimulatedError> =
+        service.ready().await.unwrap().call(request).await;
+    assert!(result.is_err(), "inner returned Err — outer must propagate");
+
+    // Let the background loop drain.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // disarm() is called before the match on result, so Err propagation
+    // is NOT abandonment — guard didn't fire.
+    assert!(
+        handler.get_abandoned().is_empty(),
+        "Err arm of future.await must disarm the guard; abandoned must not fire"
+    );
+    // And no response either, because we never reached Ok(response).
+    assert!(handler.get_responses().is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_abandoned_does_not_fire_on_normal_completion() {
     use http_body_util::BodyExt;
     use tower::ServiceExt;


### PR DESCRIPTION
## Summary

- `handle_response` only fires once the inner service returns `Ok(response)` — at which point a detached task takes over and outlives the outer future being dropped. But if the client cancels *before* headers come back, the outer future is dropped while still at `let result = future.await`. Nothing fires for the handler, even though the request was captured and may have left state (e.g. a row in \`processing\`) that the handler created.
- Add a `handle_abandoned(request_data)` hook on `RequestHandler` with a default no-op so existing implementations don't break, plus a matching `handle_abandoned_batch`.
- An `AbandonGuard` armed in `RequestLoggerService::call` synchronously `try_send`s a new `BackgroundTask::Abandoned` on drop if not disarmed first. Disarm happens once the inner future resolves (Ok or Err), so the only path that fires it is genuine future-drop while the inner service is in flight.
- Wired through `MultiHandler`'s DynHandler dispatch. `LoggingHandler` gained an `info!` for abandons.

## Test plan

- [x] Two new integration tests: one drops the outer future via `tokio::time::timeout` on a `pending_handler`, asserts exactly one abandoned event lands; the other asserts a normal completion fires `handle_response` and NOT `handle_abandoned` (disarm path).
- [x] All existing tests pass unchanged (default no-op preserves behaviour for `LoggingHandler` consumers that didn't override the new method).
- [x] `cargo test`: 14/14 integration + 12/12 doctests pass.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.

## Caller migration

Existing `RequestHandler` impls compile unchanged — the new method has a default no-op. Consumers that want to clean up per-request state on cancel can override `handle_abandoned`. dwctl's `FusilladeOutletHandler` will be the first such consumer (separate PR) to fix a real leak where realtime requests cancelled before the upstream responded would leave `fusillade.requests` rows stuck in `processing` until `processing_timeout_ms` reclaim (hours in prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)