### PR TITLE
feat!: carry response extensions through to handlers in ResponseData

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -810,6 +810,7 @@ where
                 Ok(mut response) => {
                     let response_headers = response.headers().clone();
                     let response_status = response.status();
+                    let response_extensions = response.extensions().clone();
                     let first_byte_time = SystemTime::now();
                     let duration_to_first_byte = first_byte_time
                         .duration_since(start_time)
@@ -869,6 +870,7 @@ where
                             body,
                             duration_to_first_byte,
                             duration: total_duration,
+                            extensions: response_extensions,
                         };
 
                         if tx_for_response

--- a/src/multi_handler.rs
+++ b/src/multi_handler.rs
@@ -249,6 +249,7 @@ mod tests {
             body: None,
             duration_to_first_byte: Duration::from_millis(10),
             duration: Duration::from_millis(100),
+            extensions: Default::default(),
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,7 +3,7 @@
 //! This module contains the core data structures used to represent captured
 //! HTTP requests and responses, along with background task types.
 
-use axum::http::{Method, StatusCode, Uri};
+use axum::http::{Extensions, Method, StatusCode, Uri};
 use bytes::Bytes;
 use std::collections::HashMap;
 use std::time::{Duration, SystemTime};
@@ -78,6 +78,11 @@ pub struct ResponseData {
     /// For non-streaming responses, this equals duration_to_first_byte.
     /// For streaming responses, this is the time until the stream fully completes.
     pub duration: Duration,
+    /// Response extensions as set by inner services/handlers, cloned at capture
+    /// time. Extensions never serialize to the wire, so this is the only way for
+    /// handlers to receive typed per-request annotations (e.g. routing decisions)
+    /// from the layers that produced the response.
+    pub extensions: Extensions,
 }
 
 /// Tasks sent to the background processing task.

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -211,10 +211,13 @@ async fn test_response_extensions_reach_handler() {
     let response = server.get("/annotated").await;
     assert_eq!(response.status_code(), StatusCode::OK);
 
-    // Yield to the background processing task before the blocking wait
-    // (wait_for_pairs thread-sleeps, which would starve a current-thread runtime).
-    tokio::time::sleep(Duration::from_millis(100)).await;
-    assert!(handler.wait_for_pairs(1, Duration::from_secs(1)));
+    // wait_for_pairs thread-sleeps; run it on the blocking pool so the runtime
+    // keeps driving the background processing task while we wait.
+    let waiter = handler.clone();
+    let found = tokio::task::spawn_blocking(move || waiter.wait_for_pairs(1, Duration::from_secs(5)))
+        .await
+        .unwrap();
+    assert!(found);
     let pairs = handler.get_completed_pairs();
     assert_eq!(pairs.len(), 1);
     let (_, _, response_data) = &pairs[0];

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -214,9 +214,10 @@ async fn test_response_extensions_reach_handler() {
     // wait_for_pairs thread-sleeps; run it on the blocking pool so the runtime
     // keeps driving the background processing task while we wait.
     let waiter = handler.clone();
-    let found = tokio::task::spawn_blocking(move || waiter.wait_for_pairs(1, Duration::from_secs(5)))
-        .await
-        .unwrap();
+    let found =
+        tokio::task::spawn_blocking(move || waiter.wait_for_pairs(1, Duration::from_secs(5)))
+            .await
+            .unwrap();
     assert!(found);
     let pairs = handler.get_completed_pairs();
     assert_eq!(pairs.len(), 1);

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -187,6 +187,44 @@ async fn test_basic_request_response() {
 }
 
 #[tokio::test]
+async fn test_response_extensions_reach_handler() {
+    /// Typed annotation an inner service attaches to its response — the
+    /// pattern integrators use to pass routing decisions to the handler.
+    #[derive(Clone, Debug, PartialEq)]
+    struct RoutingAnnotation(&'static str);
+
+    async fn annotating_handler() -> impl IntoResponse {
+        let mut response = "annotated".into_response();
+        response
+            .extensions_mut()
+            .insert(RoutingAnnotation("upstream-a"));
+        response
+    }
+
+    let handler = TestHandler::new();
+    let config = RequestLoggerConfig::default();
+    let app = Router::new()
+        .route("/annotated", get(annotating_handler))
+        .layer(RequestLoggerLayer::new(config, handler.clone()));
+    let server = axum_test::TestServer::new(app).unwrap();
+
+    let response = server.get("/annotated").await;
+    assert_eq!(response.status_code(), StatusCode::OK);
+
+    // Yield to the background processing task before the blocking wait
+    // (wait_for_pairs thread-sleeps, which would starve a current-thread runtime).
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert!(handler.wait_for_pairs(1, Duration::from_secs(1)));
+    let pairs = handler.get_completed_pairs();
+    assert_eq!(pairs.len(), 1);
+    let (_, _, response_data) = &pairs[0];
+    assert_eq!(
+        response_data.extensions.get::<RoutingAnnotation>(),
+        Some(&RoutingAnnotation("upstream-a"))
+    );
+}
+
+#[tokio::test]
 async fn test_request_with_body_capture() {
     let handler = TestHandler::new();
     let config = RequestLoggerConfig {
@@ -570,6 +608,7 @@ fn make_response_data() -> ResponseData {
         body: None,
         duration_to_first_byte: Duration::from_millis(1),
         duration: Duration::from_millis(10),
+        extensions: Default::default(),
     }
 }
 


### PR DESCRIPTION
## What

Adds `extensions: http::Extensions` to `ResponseData`, cloned from the inner service's response at the same point status/headers are captured.

## Why

Inner services annotate responses with typed extensions (e.g. onwards's `ServedBy` routing attribution). Extensions never serialize to the wire — they exist only in-process — so without this field there is no way for a `RequestHandler` to receive them. Headers were the only alternative, and they leak to clients unless actively stripped.

## Breaking

`ResponseData` is exhaustively constructible, so downstream code building it literally (tests, mostly) must add the field. `ResponseData` itself has no `Default` impl — but the new field can be populated with `extensions: Default::default()` (an empty `Extensions`), which reproduces pre-0.9 behavior. Consumers that only read `ResponseData` are unaffected.

## Testing

New integration test `test_response_extensions_reach_handler`: an inner handler sets a typed extension, and the test asserts it arrives intact in the handler's captured `ResponseData` (waiting on the blocking pool so the runtime keeps driving the background task). Full suite passes (38 tests), clippy clean.