### PR TITLE
feat: add graceful request logger drain

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -485,6 +485,22 @@ pub struct RequestLoggerLayer {
     tx: mpsc::Sender<BackgroundTask>,
 }
 
+/// Handle used to drain request logging during graceful shutdown.
+///
+/// Drop every [`RequestLoggerLayer`] and service derived from it before awaiting
+/// this handle. The worker then consumes all queued request data and waits for
+/// every handler batch to finish before returning.
+pub struct RequestLoggerShutdown {
+    worker: tokio::task::JoinHandle<()>,
+}
+
+impl RequestLoggerShutdown {
+    /// Wait until the request logger worker and all queued handlers finish.
+    pub async fn shutdown(self) -> Result<(), tokio::task::JoinError> {
+        self.worker.await
+    }
+}
+
 impl RequestLoggerLayer {
     /// Create a new request logger layer with the given configuration and handler.
     ///
@@ -519,6 +535,19 @@ impl RequestLoggerLayer {
     /// # }
     /// ```
     pub fn new<H: RequestHandler>(config: RequestLoggerConfig, handler: H) -> Self {
+        let (layer, _shutdown) = Self::new_with_shutdown(config, handler);
+        layer
+    }
+
+    /// Create a request logger layer and a handle for graceful shutdown.
+    ///
+    /// After the HTTP server has stopped and all clones of the layer/service
+    /// have been dropped, await the returned handle to flush the queue and wait
+    /// for all handler batches to complete.
+    pub fn new_with_shutdown<H: RequestHandler>(
+        config: RequestLoggerConfig,
+        handler: H,
+    ) -> (Self, RequestLoggerShutdown) {
         let (tx, mut rx) = mpsc::channel::<BackgroundTask>(config.channel_capacity);
         let handler = Arc::new(handler);
         let handler_clone = handler.clone();
@@ -527,7 +556,7 @@ impl RequestLoggerLayer {
         // Waits for at least one item, drains all available items, then flushes
         // the batch to the handler. This gives low latency at low load (single
         // item → immediate flush) and batching efficiency at high load.
-        tokio::spawn(async move {
+        let worker = tokio::spawn(async move {
             loop {
                 // Block until at least one item arrives (or channel closes)
                 let first = match rx.recv().await {
@@ -623,7 +652,7 @@ impl RequestLoggerLayer {
             }
         });
 
-        Self { config, tx }
+        (Self { config, tx }, RequestLoggerShutdown { worker })
     }
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -798,6 +798,69 @@ async fn test_abandoned_does_not_fire_on_normal_completion() {
     assert!(handler.get_abandoned().is_empty());
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn shutdown_waits_for_queued_handlers_to_finish() {
+    use http_body_util::BodyExt;
+    use tokio::sync::Notify;
+    use tower::ServiceExt;
+
+    #[derive(Clone)]
+    struct BlockingHandler {
+        started: Arc<Notify>,
+        release: Arc<Notify>,
+    }
+
+    impl RequestHandler for BlockingHandler {
+        async fn handle_request(&self, _request: RequestData) {}
+
+        async fn handle_response(&self, _request: RequestData, _response: ResponseData) {
+            self.started.notify_one();
+            self.release.notified().await;
+        }
+    }
+
+    let started = Arc::new(Notify::new());
+    let release = Arc::new(Notify::new());
+    let (layer, shutdown) = RequestLoggerLayer::new_with_shutdown(
+        RequestLoggerConfig::default(),
+        BlockingHandler {
+            started: Arc::clone(&started),
+            release: Arc::clone(&release),
+        },
+    );
+    let app: Router = Router::new()
+        .route("/hello", get(hello_handler))
+        .layer(layer);
+
+    let response = app
+        .clone()
+        .oneshot(
+            axum::http::Request::builder()
+                .uri("/hello")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    response.into_body().collect().await.unwrap();
+    started.notified().await;
+
+    drop(app);
+    let mut shutdown = Box::pin(shutdown.shutdown());
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), &mut shutdown)
+            .await
+            .is_err(),
+        "shutdown must wait for an in-flight handler"
+    );
+
+    release.notify_one();
+    tokio::time::timeout(Duration::from_secs(1), shutdown)
+        .await
+        .expect("shutdown timed out")
+        .expect("outlet worker panicked");
+}
+
 // ---------------------------------------------------------------------------
 // Panic safety tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- expose a shutdown handle alongside `RequestLoggerLayer`
- drain queued request/response records before shutdown completes
- wait for in-flight handler batches instead of detaching them at process exit

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

This is required by the control-layer shutdown fix so accepted requests cannot lose persistence work when SIGTERM closes its background writers.